### PR TITLE
证书续期后自动重启 xray; 修改 HSTS 为半年

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -629,7 +629,7 @@ server {
 		alias /etc/v2ray-agent/subscribe/;
 	}
 	location / {
-		add_header Strict-Transport-Security "max-age=63072000" always;
+		add_header Strict-Transport-Security "max-age=15552000; preload" always;
 	}
 }
 EOF
@@ -701,7 +701,7 @@ installTLS() {
 			sudo "$HOME/.acme.sh/acme.sh" --issue -d "${tlsDomain}" --standalone -k ec-256 >/dev/null
 		fi
 
-		sudo "$HOME/.acme.sh/acme.sh" --installcert -d "${tlsDomain}" --fullchainpath "/etc/v2ray-agent/tls/${tlsDomain}.crt" --keypath "/etc/v2ray-agent/tls/${tlsDomain}.key" --ecc >/dev/null
+		sudo "$HOME/.acme.sh/acme.sh" --installcert -d "${tlsDomain}" --fullchainpath "/etc/v2ray-agent/tls/${tlsDomain}.crt" --keypath "/etc/v2ray-agent/tls/${tlsDomain}.key" --ecc --reloadcmd "systemctl restart xray" >/dev/null
 		if [[ -z $(cat "/etc/v2ray-agent/tls/${tlsDomain}.crt") ]]; then
 			echoContent red " ---> TLS安装失败，请检查acme日志"
 			exit 0


### PR DESCRIPTION
1. acme.sh 提供 [`--reloadcmd`](https://github.com/acmesh-official/acme.sh/blob/068076c0d5cf7cfaede251788fb1461e6b1e92f9/acme.sh#L6459), [`--post-hook`](https://github.com/acmesh-official/acme.sh/blob/068076c0d5cf7cfaede251788fb1461e6b1e92f9/acme.sh#L6488), [`--renew-hook`](https://github.com/acmesh-official/acme.sh/blob/068076c0d5cf7cfaede251788fb1461e6b1e92f9/acme.sh#L6489) 三种参数供设置证书更新后要运行的指令，个人认为 `--reloadcmd` 最适合脚本使用场景
2. 修改默认 HSTS 为 Cloudflare 建议的半年，并加入 `preload` 参数提高安全性