### PR TITLE
修复dig返回多行结果导致判断不一致的问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1116,7 +1116,7 @@ checkDNSIP() {
     local publicIP=
 
     publicIP=$(getPublicIP "${type}")
-    if [[ "${publicIP}" != "${dnsIP}" ]]; then
+    if [[ ! "${dnsIP}" == *"${publicIP}"* ]]; then
         echoContent red " ---> 域名解析IP与当前服务器IP不一致\n"
         echoContent yellow " ---> 请检查域名解析是否生效以及正确"
         echoContent green " ---> 当前VPS IP：${publicIP}"


### PR DESCRIPTION
dig可能返回多行记录，比如
abc.com
1.2.3.4
这种情况仍然是正确的，但是现在脚本使用了相等判断，导致无法通过验证。
fix：我们只需要检查当前服务器IP地址包含在dig返回的结果中即可。