### PR TITLE
Set LimitNPROC in systemd config for sing-box to 10000

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2436,7 +2436,7 @@ ExecStart=${execStart}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=10
-LimitNPROC=512
+LimitNPROC=10000
 LimitNOFILE=infinity
 
 [Install]


### PR DESCRIPTION
Euserv cannot start sing-box as a system service. Setting LimitNPROC to 10000 solved the problem upon testing.