### PR TITLE
fix(脚本): 修改xray-core内核下新增socks5入站后sing-box启动异常问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6773,7 +6773,7 @@ setSocks5InboundRouting() {
             echoContent red " ---> 域名不可为空"
             exit 0
         fi
-        addSingBoxRouteRule "direct" "${socks5InboundRoutingDomain}" "socks5_inbound_route"
+        addSingBoxRouteRule "01_direct_outbound" "${socks5InboundRoutingDomain}" "socks5_inbound_route"
         local route=
         route=$(jq ".route.rules[0].inbound = [\"socks5_inbound\"]" "${singBoxConfigPath}socks5_inbound_route.json")
         route=$(echo "${route}" | jq ".route.rules[0].source_ip_cidr=${socks5InboundRoutingIPs}")


### PR DESCRIPTION
xray-core内核下新增socks5入站后，sing-box启动会提示没有direct tag，查看配置，原本的direct tag在`/etc/v2ray-agent/sing-box/conf/config`中已修改为`01_direct_outbound`，这里没有调整，导致sing-box无法正常启动。
本地修改`/etc/v2ray-agent/install.sh`后，重新新增socks5入站后正常。