### PR TITLE
feat(脚本): 优化Xray-Core默认直连域名，以解决Xray-Core下开启屏蔽大陆域名后部分场景下不能在google play…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3808,7 +3808,8 @@ EOF
         "type": "field",
         "domain": [
           "domain:gstatic.com",
-          "domain:googleapis.com"
+          "domain:googleapis.com",
+	  "domain:googleapis.cn"
         ],
         "outboundTag": "z_direct_outbound"
       }


### PR DESCRIPTION
部分国产手机默认内置Google框架，内置框架会使用services.googleapis.cn来请求，在一些客户端中的分流规则会把该域名走Proxy。 开启屏蔽大陆域名后，会禁用geosite:cn中的域名，services.googleapis.cn该域名也其中，导致流量会走blackhole_out，使google play中安装APP一直pending