### PR TITLE
fix(脚本): singbox订阅开启http proxy后，无法连接网络

### DIFF
--- a/documents/sing-box.json
+++ b/documents/sing-box.json
@@ -94,6 +94,13 @@
       }
     },
     {
+      "type": "mixed",
+      "listen": "127.0.0.1",
+      "listen_port": 1082,
+      "sniff": true,
+      "users": []
+    },
+    {
       "type": "socks",
       "tag": "socks-in",
       "listen": "127.0.0.1",


### PR DESCRIPTION
#1005 

两个场景均已测试：

1. 开启http proxy，可以正常连接网络，包括直连与代理，也能在google play中完成下载
2. 关闭http proxy，可以正常连接网络，包括直连与代理，google play中无法完成下载(一直处于pending状态)，与之前一致

> 通过对比两个订阅配置试出来的，必须保证mixed与http_proxy端口一致，原因未知