### PR TITLE
更新clashMetaProfiles，修复clash中dns无法解析域名问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8697,7 +8697,7 @@ sniffer:
 dns:
   enable: true
   prefer-h3: false
-  listen: 0.0.0.0:53
+  listen: 0.0.0.0:1503
   ipv6: true
   default-nameserver:
     - 114.114.114.114
@@ -8724,8 +8724,8 @@ dns:
     - https://mozilla.cloudflare-dns.com/dns-query#DNS&h3=true
 
   proxy-server-nameserver:
-    - 'tls://8.8.4.4'
-    - 'tls://1.0.0.1'
+    - 8.8.4.4
+    - 1.0.0.1
 
   nameserver-policy:
     "geosite:cn,private":


### PR DESCRIPTION
1. 安卓手机在未root情况下无法使用小于1024端口。
   clash meta for android日志显示“start DNS server(UDP) error: listen udp 0.0.0.0:53: bind: permission denied” 因此修改dns服务端口为1503
2. proxy-server-nameserver为代理节点域名解析服务器，DNS-over-TLS地址格式错误，导致clash meta中无法正确解析ip，修改为普通dns地址