### PR TITLE
Fix alpine check system

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1108,6 +1108,11 @@ installTools() {
         ${installType} binutils >/dev/null 2>&1
     fi
 
+    if ! find /usr/bin /usr/sbin | grep -q -w openssl; then
+        echoContent green " ---> 安装openssl"
+        ${installType} openssl >/dev/null 2>&1
+    fi
+
     if ! find /usr/bin /usr/sbin | grep -q -w ping6; then
         echoContent green " ---> 安装ping6"
         ${installType} inetutils-ping >/dev/null 2>&1

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,12 @@ checkSystem() {
         removeType='yum -y remove'
         upgrade="yum update -y --skip-broken"
         checkCentosSELinux
+    elif { [[ -f "/etc/issue" ]] && grep -qi "Alpine" /etc/issue; } || { [[ -f "/proc/version" ]] && grep -qi "Alpine" /proc/version; }; then
+        release="alpine"
+        installType='apk add'
+        upgrade="apk update"
+        removeType='apk del'
+        nginxConfigPath=/etc/nginx/http.d/
     elif { [[ -f "/etc/issue" ]] && grep -qi "debian" /etc/issue; } || { [[ -f "/proc/version" ]] && grep -qi "debian" /proc/version; } || { [[ -f "/etc/os-release" ]] && grep -qi "ID=debian" /etc/issue; }; then
         release="debian"
         installType='apt -y install'
@@ -74,12 +80,6 @@ checkSystem() {
         if grep </etc/issue -q -i "16."; then
             release=
         fi
-    elif { [[ -f "/etc/issue" ]] && grep -qi "Alpine" /etc/issue; } || { [[ -f "/proc/version" ]] && grep -qi "Alpine" /proc/version; }; then
-        release="alpine"
-        installType='apk add'
-        upgrade="apk update"
-        removeType='apk del'
-        nginxConfigPath=/etc/nginx/http.d/
     fi
 
     if [[ -z ${release} ]]; then


### PR DESCRIPTION
1. 调整 checkSystem Alpine 的检查顺序，Alpine 需要在 Debian 前，原因：注意到有的 Alpine /proc/version 中包含 Debian 关键字

```bash
~# cat /etc/issue
Welcome to Alpine Linux 3.20
Kernel \r on an \m (\l)

~# cat /proc/version
Linux version 6.8.4-2-pve (build@proxmox) (gcc (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT_DYNAMIC PMX 6.8.4-2 (2024-04-10T17:36Z)
```

2. 新增 openssl 依赖，原因：acme.sh 需要 openssl 依赖，Alpine 中不一定有