### PR TITLE
fix(脚本): 修复 DNS API 申请非通配符证书时仍签发根域导致失败

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1876,16 +1876,21 @@ selectAcmeInstallSSL() {
 # 安装SSL证书
 acmeInstallSSL() {
     local dnsAPIDomain="${tlsDomain}"
+    local dnsAPIExtraDomain="-d ${dnsTLSDomain}"
     if [[ "${dnsAPIStatus}" == "y" ]]; then
         dnsAPIDomain="*.${dnsTLSDomain}"
+    else
+        # 用户选择不使用通配符时，只为自己输入的子域申请证书，
+        # 避免脚本追加根域 -d ${dnsTLSDomain} 导致根域不属于自己（例如 dpdns.org 等公共后缀）时签发失败
+        dnsAPIExtraDomain=""
     fi
 
     if [[ "${dnsAPIType}" == "cloudflare" ]]; then
         echoContent green " ---> DNS API 生成证书中"
-        sudo CF_Token="${cfAPIToken}" "$HOME/.acme.sh/acme.sh" --issue -d "${dnsAPIDomain}" -d "${dnsTLSDomain}" --dns dns_cf -k ec-256 --server "${sslType}" ${sslIPv6} 2>&1 | tee -a /etc/v2ray-agent/tls/acme.log >/dev/null
+        sudo CF_Token="${cfAPIToken}" "$HOME/.acme.sh/acme.sh" --issue -d "${dnsAPIDomain}" ${dnsAPIExtraDomain} --dns dns_cf -k ec-256 --server "${sslType}" ${sslIPv6} 2>&1 | tee -a /etc/v2ray-agent/tls/acme.log >/dev/null
     elif [[ "${dnsAPIType}" == "aliyun" ]]; then
         echoContent green " --->  DNS API 生成证书中"
-        sudo Ali_Key="${aliKey}" Ali_Secret="${aliSecret}" "$HOME/.acme.sh/acme.sh" --issue -d "${dnsAPIDomain}" -d "${dnsTLSDomain}" --dns dns_ali -k ec-256 --server "${sslType}" ${sslIPv6} 2>&1 | tee -a /etc/v2ray-agent/tls/acme.log >/dev/null
+        sudo Ali_Key="${aliKey}" Ali_Secret="${aliSecret}" "$HOME/.acme.sh/acme.sh" --issue -d "${dnsAPIDomain}" ${dnsAPIExtraDomain} --dns dns_ali -k ec-256 --server "${sslType}" ${sslIPv6} 2>&1 | tee -a /etc/v2ray-agent/tls/acme.log >/dev/null
     else
         echoContent green " ---> 生成证书中"
         sudo "$HOME/.acme.sh/acme.sh" --issue -d "${tlsDomain}" --standalone -k ec-256 --server "${sslType}" ${sslIPv6} 2>&1 | tee -a /etc/v2ray-agent/tls/acme.log >/dev/null


### PR DESCRIPTION
## 问题

`acmeInstallSSL`（install.sh:1877）在用户回答 "是否使用 `*.xxx` 进行 API 申请通配符证书？[y/n]" 为 `n` 时，仍然会向 `acme.sh` 追加 `-d ${dnsTLSDomain}`，相当于同时申请「子域 + 根域」两张 SAN。

对自己拥有完整 zone 的用户（如 `example.com`）来说，多签一个根域 SAN 不影响功能，所以问题一直被掩盖。但对使用 [Public Suffix](https://publicsuffix.org/) 上共享后缀（如 `dpdns.org`、`is-a.dev`、`duckdns.org` 等）子域的用户，根域 zone 不属于自己，CF / 阿里云 API 无权写入 `_acme-challenge.<根域>` 的 TXT 记录，直接返回 `invalid domain`，整张证书签发失败。

## 复现

- 域名：`abc.dpdns.org`
- 选择 DNS API → cloudflare → 输入有效 CF Token
- 是否使用 `*.dpdns.org` 通配符 [y/n]：**n**
- 期待：只签 `abc.dpdns.org`
- 实际：

```text
Adding TXT value: ... for domain: _acme-challenge.abc.dpdns.org   <- 成功
Adding TXT value: ... for domain: _acme-challenge.dpdns.org       <- invalid domain
Error adding TXT record to domain: _acme-challenge.dpdns.org
```

## 修复

只有当用户明确选择通配符（`y`）时才追加根域 `-d`，`n` 分支仅签发用户输入的子域。Cloudflare 与阿里云两个分支同步修复，standalone 分支本就只签单域名，不受影响。

```bash
local dnsAPIExtraDomain="-d ${dnsTLSDomain}"
if [[ "${dnsAPIStatus}" == "y" ]]; then
    dnsAPIDomain="*.${dnsTLSDomain}"
else
    dnsAPIExtraDomain=""
fi
```

## 行为对照

| 用户选择 | 修复前命令 | 修复后命令 |
|---|---|---|
| `y` | `-d *.xxx.com -d xxx.com` | `-d *.xxx.com -d xxx.com` ✅ 无变化 |
| `n` | `-d sub.xxx.com -d xxx.com` ❌ | `-d sub.xxx.com` ✅ |

## 兼容性

- 选择 `y` 的老用户行为字节级一致（含通配符 + 根域），无任何破坏；
- 证书安装阶段（install.sh:1971-2011）通过本地是否存在 `*.<根域>_ecc` 目录决定走通配符路径还是单域路径，单域场景本就走 `--installcert -d "${tlsDomain}"`，无需改动；
- `bash -n install.sh` 通过。
