### PR TITLE
fix(脚本): 修复升级 Xray-core 时版本号为空导致下载失败

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2504,8 +2504,16 @@ updateXray() {
     if [[ -z "${coreInstallType}" || "${coreInstallType}" != "1" ]]; then
         if [[ -n "$1" ]]; then
             version=$1
+        elif [[ "${prereleaseStatus}" == "true" ]]; then
+            version=$(curl -s "https://api.github.com/repos/XTLS/Xray-core/releases?per_page=100" | jq -r "[.[]|select(.prerelease==true and .draft==false)]|sort_by(.published_at)|reverse|.[0].tag_name")
         else
-            version=$(curl -s "https://api.github.com/repos/XTLS/Xray-core/releases?per_page=5" | jq -r ".[]|select (.prerelease==${prereleaseStatus})|.tag_name" | head -1)
+            version=$(curl -s "https://api.github.com/repos/XTLS/Xray-core/releases/latest" | jq -r ".tag_name")
+        fi
+
+        if [[ -z "${version}" || "${version}" == "null" ]]; then
+            echoContent red " ---> 获取Xray-core版本失败，请检查网络或稍后重试"
+            handleXray start
+            exit 1
         fi
 
         echoContent green " ---> Xray-core版本:${version}"
@@ -2516,8 +2524,22 @@ updateXray() {
             wget -c -q "${wgetShowProgressStatus}" -P /etc/v2ray-agent/xray/ "https://github.com/XTLS/Xray-core/releases/download/${version}/${xrayCoreCPUVendor}.zip"
         fi
 
+        if [[ "$?" != "0" || ! -f "/etc/v2ray-agent/xray/${xrayCoreCPUVendor}.zip" ]]; then
+            echoContent red " ---> Xray-core下载失败，请检查网络或稍后重试"
+            rm -f "/etc/v2ray-agent/xray/${xrayCoreCPUVendor}.zip"
+            handleXray start
+            exit 1
+        fi
+
         unzip -o "/etc/v2ray-agent/xray/${xrayCoreCPUVendor}.zip" -d /etc/v2ray-agent/xray >/dev/null
         rm -rf "/etc/v2ray-agent/xray/${xrayCoreCPUVendor}.zip"
+
+        if [[ ! -f "/etc/v2ray-agent/xray/xray" ]]; then
+            echoContent red " ---> Xray-core安装失败，解压后未找到可执行文件，请稍后重试"
+            handleXray start
+            exit 1
+        fi
+
         chmod 655 /etc/v2ray-agent/xray/xray
         handleXray stop
         handleXray start


### PR DESCRIPTION
## 问题

远程升级 Xray-core 时失败，日志里 `---> Xray-core版本:` 后面是空的，接着就是 unzip 找不到文件、xray 启动失败一连串报错。

## 原因

XTLS/Xray-core 最近几个版本全标成了 prerelease，稳定版 v26.3.27 已经不在最近 5 个 release 里了。而 `updateXray` 里用 `per_page=5 + select(.prerelease==false)` 找稳定版，结果直接返回空，下载链接就成了 `.../download//Xray-linux-64.zip`，404。

这个Bug作者之前在 `remoteVersion` 和 sing-box 那边已经修过（commit f9c7c5f），只是 `updateXray` 第一个分支漏掉了。

## 改了什么

- 稳定版改用 `releases/latest` 拿版本，跟脚本里其他地方保持一致；预览版走 `per_page=100` 兜底，免得 prerelease 太靠后被漏掉
- 版本号为空 / zip 没下下来 / 解压后没有可执行文件，这几种情况都加了判断，失败就把 Xray 拉起来再退出，不至于删了旧的又没装上新的，留个裸奔的环境

在一台 Debian x86_64 上验证过：解析版本 → 下载 → 解压 → `xray --version` 正常，失败路径也能正确触发。