### PR TITLE
fix core service cleanup during switches

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1023,13 +1023,29 @@ showInstallStatus() {
     fi
 }
 
+# 清理核心服务
+removeCoreService() {
+    local serviceName=$1
+    if [[ "${release}" == "alpine" ]]; then
+        rc-update del "${serviceName}" default >/dev/null 2>&1
+        rm -f "/etc/init.d/${serviceName}"
+    elif [[ -n $(find /bin /usr/bin -name "systemctl") ]]; then
+        systemctl disable "${serviceName}.service" >/dev/null 2>&1
+        rm -f "/etc/systemd/system/${serviceName}.service"
+        systemctl daemon-reload
+        systemctl reset-failed "${serviceName}.service" >/dev/null 2>&1
+    fi
+}
+
 # 清理旧残留
 cleanUp() {
     if [[ "$1" == "xrayDel" ]]; then
         handleXray stop
+        removeCoreService xray
         rm -rf /etc/v2ray-agent/xray/*
     elif [[ "$1" == "singBoxDel" ]]; then
         handleSingBox stop
+        removeCoreService sing-box
         rm -rf /etc/v2ray-agent/sing-box/conf/config.json >/dev/null 2>&1
         rm -rf /etc/v2ray-agent/sing-box/conf/config/* >/dev/null 2>&1
     fi
@@ -2636,6 +2652,7 @@ installSingBoxService() {
 Description=Sing-Box Service
 Documentation=https://sing-box.sagernet.org
 After=network.target nss-lookup.target
+ConditionPathExists=/etc/v2ray-agent/sing-box/conf/config.json
 
 [Service]
 User=root
@@ -2643,7 +2660,7 @@ WorkingDirectory=/root
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 ExecStart=${execStart}
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/bin/kill -HUP \$MAINPID
 Restart=on-failure
 RestartSec=10
 LimitNPROC=infinity


### PR DESCRIPTION
## What changed

- remove the obsolete Xray or sing-box startup unit when switching cores
- clear stale systemd failure state after removing the old core
- keep `$MAINPID` literal in the generated sing-box systemd unit
- prevent sing-box from starting before its merged configuration exists

## Root cause

`cleanUp` removed the old core binary or configuration but left its enabled
service unit behind. After switching from Xray to sing-box, systemd continued
starting `xray.service` even though `/etc/v2ray-agent/xray/xray` no longer
existed, resulting in `203/EXEC`.

The sing-box unit was generated with an unescaped `$MAINPID` inside a heredoc,
so the shell expanded it while writing the file. This produced an incomplete
`ExecReload=/bin/kill -HUP` command.

## Impact

Core switches no longer leave a failed service enabled, sing-box reload works
correctly, and installation cannot enter a restart loop while `config.json` is
still being generated.

## Validation

- `bash -n install.sh`
- `git diff --check`
- static assertions for both cleanup paths and generated unit directives
- Debian 12 systemd validation with `systemd-analyze verify`
- restart and reload kept sing-box active with the same PID after reload
- external VLESS TCP/TLS Vision request returned HTTP 200 through the repaired
  service
