### PR TITLE
fix: 隔离宿主机 Nginx 服务生命周期

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2167,10 +2167,19 @@ updateSELinuxHTTPPortT() {
     fi
 }
 
+# 检查Nginx服务是否运行
+isNginxRunning() {
+    if [[ "${release}" == "alpine" ]]; then
+        rc-service nginx status >/dev/null 2>&1
+    else
+        systemctl is-active --quiet nginx
+    fi
+}
+
 # 操作Nginx
 handleNginx() {
 
-    if ! echo "${selectCustomInstallType}" | grep -qwE ",7,|,8,|,7,8," && [[ -z $(pgrep -f "nginx") ]] && [[ "$1" == "start" ]]; then
+    if ! echo "${selectCustomInstallType}" | grep -qwE ",7,|,8,|,7,8," && ! isNginxRunning && [[ "$1" == "start" ]]; then
         if [[ "${release}" == "alpine" ]]; then
             rc-service nginx start 2>/etc/v2ray-agent/nginx_error.log
         else
@@ -2179,10 +2188,10 @@ handleNginx() {
 
         sleep 0.5
 
-        if [[ -z $(pgrep -f "nginx") ]]; then
+        if ! isNginxRunning; then
             echoContent red " ---> Nginx启动失败"
             echoContent red " ---> 请将下方日志反馈给开发者"
-            nginx
+            nginx -t
             if grep -q "journalctl -xe" </etc/v2ray-agent/nginx_error.log; then
                 updateSELinuxHTTPPortT
             fi
@@ -2190,7 +2199,7 @@ handleNginx() {
             echoContent green " ---> Nginx启动成功"
         fi
 
-    elif [[ -n $(pgrep -f "nginx") ]] && [[ "$1" == "stop" ]]; then
+    elif isNginxRunning && [[ "$1" == "stop" ]]; then
 
         if [[ "${release}" == "alpine" ]]; then
             rc-service nginx stop
@@ -2198,10 +2207,6 @@ handleNginx() {
             systemctl stop nginx
         fi
         sleep 0.5
-
-        if [[ -z ${btDomain} && -n $(pgrep -f "nginx") ]]; then
-            pgrep -f "nginx" | xargs kill -9
-        fi
         echoContent green " ---> Nginx关闭成功"
     fi
 }
@@ -5642,7 +5647,7 @@ updateNginxBlog() {
             addNginx302 "${redirectDomain}"
             handleNginx stop
             handleNginx start
-            if [[ -z $(pgrep -f "nginx") ]]; then
+            if ! isNginxRunning; then
                 backupNginxConfig restoreBackup
                 handleNginx start
                 exit 0
@@ -5812,7 +5817,7 @@ unInstall() {
     # checkBTPanel
     echoContent yellow " ---> 脚本不会删除acme相关配置，删除请手动执行 [rm -rf /root/.acme.sh]"
     handleNginx stop
-    if [[ -z $(pgrep -f "nginx") ]]; then
+    if ! isNginxRunning; then
         echoContent green " ---> 停止Nginx成功"
     fi
     if [[ "${release}" == "alpine" ]]; then
@@ -8845,7 +8850,7 @@ EOF
         handleNginx stop
         handleNginx start
     fi
-    if [[ -z $(pgrep -f "nginx") ]]; then
+    if ! isNginxRunning; then
         handleNginx start
     fi
 }

--- a/shell/install_en.sh
+++ b/shell/install_en.sh
@@ -1709,15 +1709,20 @@ updateSELinuxHTTPPortT() {
     fi
 }
 
+# Check whether the Nginx service is running
+isNginxRunning() {
+    systemctl is-active --quiet nginx
+}
+
 #Operation Nginx
 handleNginx() {
 
-    if [[ -z $(pgrep -f "nginx") ]] && [[ "$1" == "start" ]]; then
+    if ! isNginxRunning && [[ "$1" == "start" ]]; then
         systemctl start nginx 2>/etc/v2ray-agent/nginx_error.log
 
         sleep 0.5
 
-        if [[ -z $(pgrep -f "nginx") ]]; then
+        if ! isNginxRunning; then
             echoContent red " ---> Nginx failed to start"
             echoContent red " ---> Please try to install nginx manually and execute the script again"
 
@@ -1730,12 +1735,9 @@ handleNginx() {
             echoContent green " ---> Nginx started successfully"
         fi
 
-    elif [[ -n $(pgrep -f "nginx") ]] && [[ "$1" == "stop" ]]; then
+    elif isNginxRunning && [[ "$1" == "stop" ]]; then
         systemctl stop nginx
         sleep 0.5
-        if [[ -n $(pgrep -f "nginx") ]]; then
-            pgrep -f "nginx" | xargs kill -9
-        fi
         echoContent green " ---> Nginx closed successfully"
     fi
 }
@@ -4548,7 +4550,7 @@ updateNginxBlog() {
             addNginx302 "${redirectDomain}"
             handleNginx stop
             handleNginx start
-            if [[ -z $(pgrep -f "nginx") ]]; then
+            if ! isNginxRunning; then
                 backupNginxConfig restoreBackup
                 handleNginx start
                 exit 0
@@ -4708,7 +4710,7 @@ unInstall() {
     fi
     echoContent yellow " ---> The script will not delete acme related configurations. To delete, please execute manually [rm -rf /root/.acme.sh]"
     handleNginx stop
-    if [[ -z $(pgrep -f "nginx") ]]; then
+    if ! isNginxRunning; then
         echoContent green " ---> Stop Nginx successfully"
     fi
 


### PR DESCRIPTION
## 修改内容

- 使用宿主机服务状态检查（`systemctl` 或 OpenRC）替代全局 Nginx 进程匹配。
- 删除会强制终止所有 `nginx` 匹配进程的兜底逻辑。
- 将现有其他 Nginx 状态判断统一为同一个服务检查。
- 启动失败时使用 `nginx -t` 输出诊断，避免执行裸 `nginx` 命令。

本 PR 保持证书续期、卸载、302 重定向和订阅流程的原有控制逻辑不变，只解决本地 Nginx 生命周期判断被 Docker 或其他无关 Nginx 进程干扰的问题。

## 验证

- `bash -n install.sh`
- `bash -n shell/install_en.sh`
- `git diff --check upstream/master...HEAD`
- 本地模拟回归测试：systemd/OpenRC 启停、active/inactive 幂等、Docker Nginx 误匹配、自定义安装类型 7，以及 `nginx -t` 诊断

Closes #1339
