### PR TITLE
解决ngxin监测会识别到docker容器中的nginx的问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1421,7 +1421,10 @@ checkPortOpen() {
 
     if [[ -z "${btDomain}" ]]; then
 
-        handleNginx stop
+        if ! handleNginx stop; then
+            echoContent red " ---> 无法停止Nginx，退出端口检测"
+            exit 1
+        fi
         # 初始化nginx配置
         touch ${nginxConfigPath}checkPortOpen.conf
         local listenIPv6PortConfig=
@@ -1447,12 +1450,19 @@ server {
     }
 }
 EOF
-        handleNginx start
+        if ! handleNginx start; then
+            rm -f "${nginxConfigPath}checkPortOpen.conf"
+            echoContent red " ---> Nginx启动失败，无法检测端口，请检查服务日志及端口占用"
+            exit 1
+        fi
         # 检查域名+端口的开放
         checkPortOpenResult=$(curl -s -m 10 "http://${domain}:${port}/checkPort")
         localIP=$(curl -s -m 10 "http://${domain}:${port}/ip")
         rm "${nginxConfigPath}checkPortOpen.conf"
-        handleNginx stop
+        if ! handleNginx stop; then
+            echoContent red " ---> 无法停止端口检测服务，退出安装"
+            exit 1
+        fi
         if [[ "${checkPortOpenResult}" == "fjkvymb6len" ]]; then
             echoContent green " ---> 检测到${port}端口已开放"
         else
@@ -2164,47 +2174,64 @@ updateSELinuxHTTPPortT() {
             $(find /usr/bin /usr/sbin | grep -w semanage) port -a -t http_port_t -p tcp 31302
             echoContent green " ---> http_port_t 31302 端口开放成功"
         fi
-        handleNginx start
+        return 0
 
     else
-        exit 0
+        return 1
     fi
 }
 
 # 操作Nginx
 handleNginx() {
+    # 使用宿主机服务状态，避免匹配或终止容器中的Nginx进程。
+    local -a nginxStart nginxStop nginxStatus
+    if [[ "${release}" == "alpine" ]]; then
+        nginxStart=(rc-service nginx start)
+        nginxStop=(rc-service nginx stop)
+        nginxStatus=(rc-service nginx status)
+    else
+        nginxStart=(systemctl start nginx)
+        nginxStop=(systemctl stop nginx)
+        nginxStatus=(systemctl is-active --quiet nginx)
+    fi
 
-    if ! echo "${selectCustomInstallType}" | grep -qwE ",7,|,8,|,7,8," && [[ -z $(pgrep -f "nginx") ]] && [[ "$1" == "start" ]]; then
-        if [[ "${release}" == "alpine" ]]; then
-            rc-service nginx start 2>/etc/v2ray-agent/nginx_error.log
-        else
-            systemctl start nginx 2>/etc/v2ray-agent/nginx_error.log
+    if [[ "$1" == "start" ]]; then
+        if echo "${selectCustomInstallType}" | grep -qwE ",7,|,8,|,7,8,"; then
+            return 0
+        fi
+        if "${nginxStatus[@]}" >/dev/null 2>&1; then
+            return 0
         fi
 
-        sleep 0.5
-
-        if [[ -z $(pgrep -f "nginx") ]]; then
-            echoContent red " ---> Nginx启动失败"
-            echoContent red " ---> 请将下方日志反馈给开发者"
-            nginx
-            if grep -q "journalctl -xe" </etc/v2ray-agent/nginx_error.log; then
-                updateSELinuxHTTPPortT
+        local startResult=0
+        "${nginxStart[@]}" 2>/etc/v2ray-agent/nginx_error.log || startResult=$?
+        if [[ "${startResult}" -ne 0 ]] || ! "${nginxStatus[@]}" >/dev/null 2>&1; then
+            # SELinux修复成功后只重试一次，避免递归启动。
+            if [[ "${release}" != "alpine" ]] && updateSELinuxHTTPPortT; then
+                startResult=0
+                "${nginxStart[@]}" 2>/etc/v2ray-agent/nginx_error.log || startResult=$?
             fi
-        else
-            echoContent green " ---> Nginx启动成功"
+            if [[ "${startResult}" -ne 0 ]] || ! "${nginxStatus[@]}" >/dev/null 2>&1; then
+                echoContent red " ---> Nginx启动失败，请检查服务日志及端口占用"
+                cat /etc/v2ray-agent/nginx_error.log
+                # 仅检查配置，不直接启动脱离服务管理的Nginx进程。
+                nginx -t || true
+                return 1
+            fi
         fi
+        echoContent green " ---> Nginx启动成功"
 
-    elif [[ -n $(pgrep -f "nginx") ]] && [[ "$1" == "stop" ]]; then
-
-        if [[ "${release}" == "alpine" ]]; then
-            rc-service nginx stop
-        else
-            systemctl stop nginx
+    elif [[ "$1" == "stop" ]]; then
+        if ! "${nginxStatus[@]}" >/dev/null 2>&1; then
+            return 0
         fi
-        sleep 0.5
-
-        if [[ -z ${btDomain} && -n $(pgrep -f "nginx") ]]; then
-            pgrep -f "nginx" | xargs kill -9
+        if ! "${nginxStop[@]}"; then
+            echoContent red " ---> Nginx关闭失败，请检查宿主机服务状态"
+            return 1
+        fi
+        if "${nginxStatus[@]}" >/dev/null 2>&1; then
+            echoContent red " ---> Nginx仍在运行，请检查宿主机服务状态"
+            return 1
         fi
         echoContent green " ---> Nginx关闭成功"
     fi

--- a/tests/nginx-service.sh
+++ b/tests/nginx-service.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Isolated regression tests: no root, network, nginx or service manager required.
+set -euo pipefail
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+# Load only the functions under test; sourcing install.sh would run the installer.
+{
+    sed -n '/^handleNginx() {$/,/^# 定时任务更新tls证书/p' "$repo_dir/install.sh"
+    sed -n '/^checkPortOpen() {$/,/^# 初始化Nginx申请证书配置/p' "$repo_dir/install.sh"
+} | sed "s@/etc/v2ray-agent/nginx_error.log@${test_dir}/nginx_error.log@g" > "$test_dir/functions.sh"
+source "$test_dir/functions.sh"
+
+echoContent() { printf '%s\n' "$*" >> "$test_dir/messages"; }
+pgrep() { echo pgrep >> "$test_dir/unsafe"; return 0; }
+kill() { echo kill >> "$test_dir/unsafe"; return 1; }
+nginx() {
+    printf '%s\n' "$*" >> "$test_dir/nginx-calls"
+    [[ "$*" == '-t' ]]
+}
+updateSELinuxHTTPPortT() {
+    repairs=$((repairs + 1))
+    [[ "$repairable" == yes ]] || return 1
+    fail_start=no
+}
+mock_service() {
+    printf '%s\n' "$1" >> "$test_dir/service-calls"
+    case "$1" in
+    status) [[ "$state" == active ]];;
+    start)
+        starts=$((starts + 1))
+        [[ "$fail_start" == no ]] || return 1
+        [[ "$inactive_after_start" == yes ]] || state=active
+        ;;
+    stop)
+        [[ "$fail_stop" == no ]] || return 1
+        [[ "$active_after_stop" == yes ]] || state=inactive
+        ;;
+    *) return 99;;
+    esac
+}
+systemctl() {
+    [[ "$release" != alpine ]] || return 99
+    case "$*" in
+    'is-active --quiet nginx') mock_service status;;
+    'start nginx') mock_service start;;
+    'stop nginx') mock_service stop;;
+    *) return 99;;
+    esac
+}
+rc-service() {
+    [[ "$release" == alpine && "$1" == nginx ]] || return 99
+    mock_service "$2"
+}
+handleSingBox() { :; }
+handleXray() { :; }
+allowPort() { :; }
+checkIP() { printf '%s\n' "$1" > "$test_dir/checked-ip"; }
+curl() {
+    case "$*" in
+    *cdn-cgi/trace*) return 0;;
+    *checkPort*) echo request >> "$test_dir/requests"; printf fjkvymb6len;;
+    */ip) printf 192.0.2.1;;
+    *) return 99;;
+    esac
+}
+
+run_case() (
+    local release=$1 scenario=$2
+    local state=inactive starts=0 repairs=0 fail_start=no fail_stop=no
+    local repairable=no inactive_after_start=no active_after_stop=no
+    local selectCustomInstallType='' btDomain='' localIP=''
+    local nginxConfigPath="$test_dir/"
+    rm -f "$test_dir/unsafe" "$test_dir/messages" "$test_dir/nginx-calls" \
+        "$test_dir/service-calls" "$test_dir/requests" "$test_dir/checked-ip" \
+        "$test_dir/checkPortOpen.conf"
+    case "$scenario" in
+    lifecycle)
+        handleNginx start
+        [[ "$state" == active && "$starts" == 1 ]]
+        handleNginx start
+        [[ "$starts" == 1 ]]
+        handleNginx stop
+        [[ "$state" == inactive ]]
+        handleNginx stop
+        ;;
+    start_failure)
+        fail_start=yes
+        if handleNginx start; then exit 1; fi
+        [[ "$starts" == 1 && "$state" == inactive ]]
+        [[ "$(cat "$test_dir/nginx-calls")" == '-t' ]]
+        ;;
+    inactive_after_start)
+        inactive_after_start=yes
+        if handleNginx start; then exit 1; fi
+        ;;
+    selinux_retry)
+        fail_start=yes repairable=yes
+        if [[ "$release" == alpine ]]; then
+            if handleNginx start; then exit 1; fi
+            [[ "$starts" == 1 && "$repairs" == 0 ]]
+        else
+            handleNginx start
+            [[ "$starts" == 2 && "$repairs" == 1 && "$state" == active ]]
+        fi
+        ;;
+    bounded_retry)
+        inactive_after_start=yes repairable=yes
+        if handleNginx start; then exit 1; fi
+        [[ "$starts" -le 2 && "$repairs" -le 1 ]]
+        ;;
+    stop_failure)
+        state=active fail_stop=yes
+        if handleNginx stop; then exit 1; fi
+        [[ "$state" == active ]]
+        ;;
+    active_after_stop)
+        state=active active_after_stop=yes
+        if handleNginx stop; then exit 1; fi
+        ;;
+    skip_nginx)
+        selectCustomInstallType=',7,'
+        handleNginx start
+        [[ "$starts" == 0 ]]
+        ;;
+    probe_success)
+        checkPortOpen 20028 example.invalid
+        [[ ! -e "$test_dir/checkPortOpen.conf" && "$state" == inactive ]]
+        [[ "$(cat "$test_dir/checked-ip")" == 192.0.2.1 ]]
+        ;;
+    probe_start_failure)
+        fail_start=yes
+        if (checkPortOpen 20028 example.invalid); then exit 1; fi
+        [[ ! -e "$test_dir/checkPortOpen.conf" && ! -e "$test_dir/requests" ]]
+        ! grep -q '未检测到.*端口开放' "$test_dir/messages"
+        ;;
+    probe_stop_failure)
+        state=active fail_stop=yes
+        if (checkPortOpen 20028 example.invalid); then exit 1; fi
+        [[ ! -e "$test_dir/checkPortOpen.conf" && ! -e "$test_dir/requests" ]]
+        ;;
+    esac
+    [[ ! -e "$test_dir/unsafe" ]]
+    printf 'PASS %s / %s\n' "$release" "$scenario"
+)
+for manager in debian alpine; do
+    for scenario in lifecycle start_failure inactive_after_start selinux_retry bounded_retry \
+        stop_failure active_after_stop skip_nginx probe_success probe_start_failure probe_stop_failure; do
+        run_case "$manager" "$scenario"
+    done
+done


### PR DESCRIPTION
<img width="625" height="230" alt="image" src="https://github.com/user-attachments/assets/fffb4ce2-cc0f-4b3a-af79-c1a28fe9139d" />
修复后不再把docker里的nginx作为可用nginx，会自动安装新的
<img width="730" height="306" alt="image" src="https://github.com/user-attachments/assets/88136336-aa1c-4081-a8bd-4693e46fab0e" />

已测试通过